### PR TITLE
first working version for pca plot & analysis

### DIFF
--- a/tools/dimet/dimet_abundance_plot.xml
+++ b/tools/dimet/dimet_abundance_plot.xml
@@ -215,7 +215,7 @@
                 <param name="width_each_subfig" value="3.0"/>
                 <param name="height_each_subfig" value="5.5"/>
             </section>
-            <output name="report" file="report.html" count="9"/>
+            <output name="report" file="report.html"/>
         </test>
         <!-- test with dataset1 -->
         <test>
@@ -231,7 +231,7 @@
                 <param name="width_each_subfig" value="3"/>
                 <param name="height_each_subfig" value="5.5"/>
             </section>
-            <output name="report" file="report.html" count="7"/>
+            <output name="report" file="report.html"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/dimet/dimet_differential_analysis.xml
+++ b/tools/dimet/dimet_differential_analysis.xml
@@ -393,7 +393,7 @@
             <param name="conditions" value='"Control","L-Cycloserine"'/>
             <param name="timepoint" value='"T0","T2h"'/>
             <param name="grouping" value="condition,timepoint"/>
-            <output name="report" file="report.html" count="6"/>
+            <output name="report" file="report.html"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/dimet/dimet_differential_multigroup_analysis.xml
+++ b/tools/dimet/dimet_differential_multigroup_analysis.xml
@@ -461,7 +461,7 @@
                 <param name="width_each_stack" value="3.0"/>
                 <param name="max_nb_carbons_possible" value="12"/>
             </section>
-            <output name="report" file="report.html" count="3"/>
+            <output name="report" file="report.html"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/dimet/dimet_enrichment_plot.xml
+++ b/tools/dimet/dimet_enrichment_plot.xml
@@ -209,7 +209,7 @@
             <section name="output_options">
                 <param name="width_each_subfig" value="3.0"/>
             </section>
-            <output name="report" file="report.html" count="8"/>
+            <output name="report" file="report.html"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/dimet/dimet_isotopologues_plot.xml
+++ b/tools/dimet/dimet_isotopologues_plot.xml
@@ -232,7 +232,7 @@
                 <param name="x_ticks_text_size" value="18"/>
                 <param name="y_ticks_text_size" value="18"/>
             </section>
-            <output name="report" file="report.html" count="9"/>
+            <output name="report" file="report.html"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/dimet/dimet_isotopologues_plot.xml
+++ b/tools/dimet/dimet_isotopologues_plot.xml
@@ -100,31 +100,9 @@
         <param name="isotop_prop_file" type="data" format="tabular" label="Isotopologues proportion abundance file"/>
         <param name="isotop_abs_file" type="data" optional="true" format="tabular" label="Isotopologues absolute abundance file"/>
         <param name="metadata_path" type="data" format="tabular" label="metadata file"/>
-        <param name="suffix" type="text" optional="false" label="suffix to add to output files" >
-            <sanitizer invalid_char="">
-                <valid initial="string.ascii_letters,string.digits">
-                    <add value="_" />
-                </valid>
-            </sanitizer>
-        </param>
-        <param name="conditions" type="select" optional="false" multiple="true"
-               label="Browse conditions from metadata file (2 Max.). You have to load a metadata file prior to have acccess to metabolite list">
-            <options from_dataset="metadata_path">
-                <column name="condition" index="1"/>
-                <column name="value" index="1"/>
-                <filter type="unique_value" name="condition" column="condition"/>
-                <filter type="remove_value" value="condition"/>
-                <!--                <filter type="sort_by" name="timepoint" column="1"/>-->
-            </options>
-            <sanitizer>
-                <valid initial="default">
-                    <add preset="string.printable"/>
-                    <add value="\t"/>
-                    <remove value="&quot;"/>
-                    <remove value="&apos;"/>
-                </valid>
-            </sanitizer>
-        </param>
+        <expand macro="suffix"/>
+        <expand macro="conditions"/>
+
         <param name="metabolites_list" type="select" optional="false" multiple="true"
                label="Select Metabolite(s) to plot (2 Max.). You have to load a abundance file prior to have acccess to metabolite list">
             <validator type="length" min="1" message="Please enter at max 2 compartments"/>
@@ -145,24 +123,9 @@
                 </valid>
             </sanitizer>
         </param>
-        <param name="timepoint" type="select" optional="false" multiple="true"
-               label="Browse timepoint from metadata file (2 Max.). You have to load a metadata file prior to have acccess to metabolite list">
-            <options from_dataset="metadata_path">
-                <column name="timepoint" index="2"/>
-                <column name="value" index="2"/>
-                <filter type="unique_value" name="timepoint" column="2"/>
-                <filter type="remove_value" value="timepoint"/>
-                <!--                <filter type="sort_by" name="timepoint" column="1"/>-->
-            </options>
-            <sanitizer>
-                <valid initial="default">
-                    <add preset="string.printable"/>
-                    <add value="\t"/>
-                    <remove value="&quot;"/>
-                    <remove value="&apos;"/>
-                </valid>
-            </sanitizer>
-        </param>
+
+        <expand macro="timepoint"/>
+
         <param name="compartments" type="select" optional="false" multiple="true"
                label="Browse compartments from metadata file (2 Max.). You have to load a metadata file prior to have acccess to metabolite list">
 <!--            <validator type="length" min="1" message="Please enter at min 1 compartments"/>-->

--- a/tools/dimet/dimet_metabologram.xml
+++ b/tools/dimet/dimet_metabologram.xml
@@ -206,48 +206,9 @@
         <param name="path_kegg_metabolites" type="data" format="tabular" label="Pathways kegg metabolites file"/>
         <param name="path_kegg_transcripts" type="data" format="tabular" label="Pathways kegg transcripts file"/>
         <param name="metadata_path" type="data" format="tabular" label="metadata file"/>
-        <param name="suffix" type="text" optional="false" label="suffix to add to output files" >
-            <sanitizer invalid_char="">
-                <valid initial="string.ascii_letters,string.digits">
-                    <add value="_" />
-                </valid>
-            </sanitizer>
-        </param>
-
-        <param name="conditions" type="select" optional="true" multiple="true" label="Browse conditions from metadata file (2 Max.). You have to load a metadata file prior to have acccess to metabolite list">
-            <options from_dataset="metadata_path">
-                <column name="condition" index="1"/>
-                <column name="value" index="1"/>
-                <filter type="unique_value" name="condition" column="condition"/>
-                <filter type="remove_value" value="condition"/>
-                <!--                <filter type="sort_by" name="timepoint" column="1"/>-->
-            </options>
-            <sanitizer>
-                <valid initial="default">
-                    <add preset="string.printable"/>
-                    <add value="\t"/>
-                    <remove value="&quot;"/>
-                    <remove value="&apos;"/>
-                </valid>
-            </sanitizer>
-        </param>
-        <param name="timepoint" type="select" optional="true" multiple="true" label="Browse timepoint from metadata file (2 Max.)">
-            <options from_dataset="metadata_path">
-                <column name="timepoint" index="2"/>
-                <column name="value" index="2"/>
-                <filter type="unique_value" name="timepoint" column="2"/>
-                <filter type="remove_value" value="timepoint"/>
-                <filter type="sort_by" name="timepoint" column="1"/>
-            </options>
-            <sanitizer>
-                <valid initial="default">
-                    <add preset="string.printable"/>
-                    <add value="\t"/>
-                    <remove value="&quot;"/>
-                    <remove value="&apos;"/>
-                </valid>
-            </sanitizer>
-        </param>
+        <expand macro="suffix"/>
+        <expand macro="conditions"/>
+        <expand macro="timepoint"/>
 
         <param name="grouping" type="select"  optional="false" multiple="true" label="Browse group to compare">
             <option value="condition" selected="true">condition</option>

--- a/tools/dimet/dimet_metabologram.xml
+++ b/tools/dimet/dimet_metabologram.xml
@@ -328,7 +328,7 @@
             <param name="conditions" value='"Control","L-Cycloserine"'/>
             <param name="timepoint" value='"T0"'/>
             <param name="grouping" value="condition,timepoint"/>
-            <output name="report" file="report.html" count="5"/>
+            <output name="report" file="report.html"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/dimet/dimet_pca_analysis.xml
+++ b/tools/dimet/dimet_pca_analysis.xml
@@ -8,53 +8,21 @@
     </macros>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
-    #import json
-    #import re
+    @INIT@
 
-    mkdir -p '${report.extra_files_path}'/output/${suffix}-pca-analysis-tables/tables &&
-    mkdir -p '${report.extra_files_path}'/raw &&
-    mkdir -p '${report.extra_files_path}'/processed &&
-    cp -R '$__tool_directory__/config' '${report.extra_files_path}'/config &&
-    #if $metadata_path:
-        cp '$metadata_path' '${report.extra_files_path}'/raw/metadata.csv &&
-    #end if
-
-    #set $impute_values  = {}
-    #if $abundance_file:
-        cp '$abundance_file' '${report.extra_files_path}'/raw/abundance.csv &&
-        #silent $impute_values['abundances']=re.sub('"', '', "min")
-    #end if
-    #if $me_or_frac_contrib_file:
-        cp '$me_or_frac_contrib_file' '${report.extra_files_path}'/raw/me_or_frac_contrib.csv &&
-        #silent $impute_values['mean_enrichment']=re.sub('"', '', "min")
-    #end if
-    #if $isotop_abs_file:
-        cp '$isotop_abs_file' '${report.extra_files_path}'/raw/isotop_abs.csv &&
-        #silent $impute_values['isotop_abs']=re.sub('"', '', "min")
-    #end if
-
-    #if $isotop_prop_file:
-        cp '$isotop_prop_file' '${report.extra_files_path}'/raw/isotop_prop.csv &&
-        #silent $impute_values['isotop_prop']=re.sub('"', '', "min")
-    #end if
-
-    #set $conds = list()
-    #for $co in $conditions:
-        $conds.append(re.sub('"', '', str($co)))
-    #end for
     HYDRA_FULL_ERROR=1 python -m dimet
-        -cd '${report.extra_files_path}'/config
+        -cd '$__tool_directory__/config'
         -cn general_config_pca_table
-        '++hydra.run.dir='${report.extra_files_path}'/'${suffix}'-pca-analysis-tables'
+        '++hydra.run.dir=${suffix}-pca-analysis-tables'
         '++figure_path=figures'
         '++table_path=tables'
         '+analysis={
             dataset:{
-                _target_:data.DatasetConfig,
+                _target_:dimet.data.DatasetConfig,
                 name: "Galaxy DIMet run"
             },
             method:{
-                _target_: method.PcaAnalysisConfig,
+                _target_: dimet.method.PcaAnalysisConfig,
                 label: pca-analysis-tables,
                 name: "Generate Principal Component Analysis tables",
                 pca_split_further:['timepoint'],
@@ -64,7 +32,7 @@
             },
             label: pca-table
         }'
-        '+analysis.dataset.subfolder='${report.extra_files_path}''
+        '+analysis.dataset.subfolder='
         '+analysis.dataset.label='${suffix}''
         '+analysis.dataset.conditions=${conds}'
         #if $metadata_path:
@@ -82,14 +50,6 @@
         #if $isotop_abs_file:
             '+analysis.dataset.isotopologues=isotop_abs'
         #end if
-
-    && cp '${report.extra_files_path}'/'${suffix}'-pca-analysis-tables/tables/*.csv ./.
-    && rm -r '${report.extra_files_path}'/raw
-    && rm -r '${report.extra_files_path}'/config
-
-
-
-
     ]]></command>
     <inputs>
         <param name="abundance_file" type="data" format="tabular" label="Metabolite abundance file"/>
@@ -133,9 +93,9 @@
     </inputs>
 
     <outputs>
-        <data name="report" format="html">
-            <discover_datasets pattern="__designation_and_ext__" directory="." visible="true" />
-        </data>
+        <collection name="report" type="list">
+            <discover_datasets pattern="__designation_and_ext__" directory="tables" format="csv"/>
+        </collection>
     </outputs>
     <tests>
         <test>
@@ -145,7 +105,7 @@
             <param name="isotop_prop_file" ftype="tabular" value="CorrectedIsotopologues.csv"/>
             <param name="suffix" value="toy1a001"/>
             <param name="conditions" value='"Control","L-Cycloserine"'/>
-            <output name="report" file="report.html" count="26"/>
+            <output name="report" file="report.html"/>
         </test>
 <!--        <test>-->
 <!--            <param name="abundance_file" ftype="tabular" value="rawAbundances.csv" />-->

--- a/tools/dimet/dimet_pca_analysis.xml
+++ b/tools/dimet/dimet_pca_analysis.xml
@@ -52,36 +52,9 @@
         #end if
     ]]></command>
     <inputs>
-        <param name="abundance_file" type="data" format="tabular" label="Metabolite abundance file"/>
-        <param name="me_or_frac_contrib_file" type="data" optional="true" format="tabular" label="Mean enrichment or fraction contribution file"/>
-        <param name="isotop_prop_file" type="data" optional="true" format="tabular" label="Isotopologues proportion abundance file"/>
-        <param name="isotop_abs_file" type="data" optional="true" format="tabular" label="Isotopologues absolute abundance file"/>
-        <param name="metadata_path" type="data" format="tabular" label="metadata file"/>
-        <param name="suffix" type="text" optional="false" label="suffix to add to output files" >
-            <sanitizer invalid_char="">
-                <valid initial="string.ascii_letters,string.digits">
-                    <add value="_" />
-                </valid>
-            </sanitizer>
-        </param>
-        <param name="conditions" type="select" optional="false" multiple="true" label="Browse conditions from metadata file (2 Max.). You have to load a metadata file prior to have acccess to metabolite list">
-            <options from_dataset="metadata_path">
-                <column name="condition" index="1"/>
-                <column name="value" index="1"/>
-                <filter type="unique_value" name="condition" column="condition"/>
-                <filter type="remove_value" value="condition"/>
-                <!--                <filter type="sort_by" name="timepoint" column="1"/>-->
-            </options>
-            <sanitizer>
-                <valid initial="default">
-                    <add preset="string.printable"/>
-                    <add value="\t"/>
-                    <remove value="&quot;"/>
-                    <remove value="&apos;"/>
-                </valid>
-            </sanitizer>
-        </param>
-
+        <expand macro="input_parameters"/>
+        <expand macro="suffix"/>
+        <expand macro="conditions"/>
 <!--        <section name="output_options" title="Output options">-->
 <!--            <param name="axisx_labeltilt" type="integer" min="0" max="180" value="90" label="X axis label tilt (bar plot)" help="Default value is 90. This option is only meaninful when plots are generated" />-->
 <!--            <param name="width_each_subfig" type="integer" min="1" max="15" value="3" label="space between plots (bar plot)" help="Default value is 3. This option is only meaninful when plots are generated" />-->

--- a/tools/dimet/dimet_pca_plot.xml
+++ b/tools/dimet/dimet_pca_plot.xml
@@ -8,54 +8,23 @@
     </macros>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
-    #import json
-    #import re
+    @INIT@
+    tree . &&
 
-    mkdir -p '${report.extra_files_path}'/output/${suffix}-pca-plot/figures &&
-    mkdir -p '${report.extra_files_path}'/raw &&
-    mkdir -p '${report.extra_files_path}'/processed &&
-    cp -R '$__tool_directory__/config' '${report.extra_files_path}'/config &&
-
-    #if $metadata_path:
-        cp '$metadata_path' '${report.extra_files_path}'/raw/metadata.csv &&
-    #end if
-
-    #set $impute_values  = {}
-    #if $abundance_file:
-        cp '$abundance_file' '${report.extra_files_path}'/raw/abundance.csv &&
-        #silent $impute_values['abundances']=re.sub('"', '', "min")
-    #end if
-    #if $me_or_frac_contrib_file:
-        cp '$me_or_frac_contrib_file' '${report.extra_files_path}'/raw/me_or_frac_contrib.csv &&
-        #silent $impute_values['mean_enrichment']=re.sub('"', '', "min")
-    #end if
-    #if $isotop_abs_file:
-        cp '$isotop_abs_file' '${report.extra_files_path}'/raw/isotop_abs.csv &&
-        #silent $impute_values['isotop_abs']=re.sub('"', '', "min")
-    #end if
-
-    #if $isotop_prop_file:
-        cp '$isotop_prop_file' '${report.extra_files_path}'/raw/isotop_prop.csv &&
-        #silent $impute_values['isotop_prop']=re.sub('"', '', "min")
-    #end if
-    #set $conds = list()
-    #for $co in $conditions:
-        $conds.append(re.sub('"', '', str($co)))
-    #end for
     HYDRA_FULL_ERROR=1 python -m dimet
-        -cd '${report.extra_files_path}'/config
+        -cd '$__tool_directory__/config'
         -cn general_config_pca_plot
-        '++hydra.run.dir='${report.extra_files_path}'/${suffix}-pca-plot'
+        '++hydra.run.dir=${suffix}-pca-plot'
         ### '++hydra.job.chdir=true'
         '++figure_path=figures'
         '++table_path=tables'
         '+analysis={
             dataset:{
-                _target_:data.DatasetConfig,
+                _target_:dimet.data.DatasetConfig,
                 name: "Galaxy DIMet run"
             },
             method:{
-                _target_: method.PcaPlotConfig,
+                _target_: dimet.method.PcaPlotConfig,
                 label: pca-plot,
                 name: "Generate Principal Component Analysis plots",
                 pca_split_further:['timepoint'],
@@ -65,7 +34,7 @@
             },
             label: pca-plot
         }'
-         '+analysis.dataset.subfolder='${report.extra_files_path}''
+         '+analysis.dataset.subfolder='
          '+analysis.dataset.label='${suffix}''
          '+analysis.dataset.conditions=${conds}'
         #if $metadata_path:
@@ -83,12 +52,7 @@
         #if $isotop_abs_file:
             '+analysis.dataset.isotopologues=isotop_abs'
         #end if
-
-    && cp '${report.extra_files_path}'/'${suffix}'-pca-plot/figures/*.pdf ./.
-    && rm -r '${report.extra_files_path}'/raw
-    && rm -r '${report.extra_files_path}'/config
-
-
+    && tree .
     ]]></command>
     <inputs>
         <param name="abundance_file" type="data" format="tabular" label="Metabolite abundance file"/>
@@ -124,9 +88,9 @@
     </inputs>
 
     <outputs>
-        <data name="report" format="html">
-            <discover_datasets pattern="__designation_and_ext__" directory="." visible="true" />
-        </data>
+        <collection name="report" type="list">
+            <discover_datasets pattern="__designation_and_ext__" directory="figures" format="pdf"/>
+        </collection>
     </outputs>
     <tests>
         <test>
@@ -136,78 +100,8 @@
             <param name="isotop_prop_file" ftype="tabular" value="CorrectedIsotopologues.csv"/>
             <param name="suffix" value="toy1a001"/>
             <param name="conditions" value='"Control","L-Cycloserine"'/>
-            <output name="report" file="report.html" count="38"/>
+            <output name="report" file="report.html"/>
         </test>
-<!--        <test>-->
-<!--            <param name="abundance_file" ftype="tabular" value="rawAbundances.csv" />-->
-<!--            <param name="me_or_frac_contrib_file" ftype="tabular" value="FracContribution_C.csv"/>-->
-<!--            <param name="metadata_path" ftype="tabular" value="example2_metadata.csv"/>-->
-<!--            <param name="isotop_prop_file" ftype="tabular" value="CorrectedIsotopologues.csv"/>-->
-<!--            <param name="suffix" value="toy1a001"/>-->
-<!--            <param name="conditions" value='"Control","L-Cycloserine"'/>-->
-<!--            <output name="report">-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;cell_pc" ftype="tsv" file="abundances&#45;&#45;cell_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;cell_var" ftype="tsv" file="abundances&#45;&#45;cell_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;med_pc" ftype="tsv" file="abundances&#45;&#45;med_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;med_var" ftype="tsv" file="abundances&#45;&#45;med_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T0&#45;&#45;cell_pc" ftype="tsv" file="abundances&#45;&#45;T0&#45;&#45;cell_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T0&#45;&#45;cell_var" ftype="tsv" file="abundances&#45;&#45;T0&#45;&#45;cell_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T0&#45;&#45;med_pc" ftype="tsv" file="abundances&#45;&#45;T0&#45;&#45;med_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T0&#45;&#45;med_var" ftype="tsv" file="abundances&#45;&#45;T0&#45;&#45;med_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T2h&#45;&#45;cell_pc" ftype="tsv" file="abundances&#45;&#45;T2h&#45;&#45;cell_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T2h&#45;&#45;cell_var" ftype="tsv" file="abundances&#45;&#45;T2h&#45;&#45;cell_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T2h&#45;&#45;med_pc" ftype="tsv" file="abundances&#45;&#45;T2h&#45;&#45;med_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T2h&#45;&#45;med_var" ftype="tsv" file="abundances&#45;&#45;T2h&#45;&#45;med_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;cell_pc" ftype="tsv" file="mean_enrichment&#45;&#45;cell_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;cell_var" ftype="tsv" file="mean_enrichment&#45;&#45;cell_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;med_pc" ftype="tsv" file="mean_enrichment&#45;&#45;med_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;med_var" ftype="tsv" file="mean_enrichment&#45;&#45;med_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T0&#45;&#45;cell_pc" ftype="tsv" file="mean_enrichment&#45;&#45;T0&#45;&#45;cell_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T0&#45;&#45;cell_var" ftype="tsv" file="mean_enrichment&#45;&#45;T0&#45;&#45;cell_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T0&#45;&#45;med_pc" ftype="tsv" file="mean_enrichment&#45;&#45;T0&#45;&#45;med_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T0&#45;&#45;med_var" ftype="tsv" file="mean_enrichment&#45;&#45;T0&#45;&#45;med_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T2h&#45;&#45;cell_pc" ftype="tsv" file="mean_enrichment&#45;&#45;T2h&#45;&#45;cell_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T2h&#45;&#45;cell_var" ftype="tsv" file="mean_enrichment&#45;&#45;T2h&#45;&#45;cell_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T2h&#45;&#45;med_pc" ftype="tsv" file="mean_enrichment&#45;&#45;T2h&#45;&#45;med_pc.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T2h&#45;&#45;med_var" ftype="tsv" file="mean_enrichment&#45;&#45;T2h&#45;&#45;med_var.tsv" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;cell&#45;&#45;label-n_pc" ftype="pdf" file="abundances&#45;&#45;cell&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;cell&#45;&#45;label-y_pc" ftype="pdf" file="abundances&#45;&#45;cell&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;cell_var" ftype="pdf" file="abundances&#45;&#45;cell_var.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;med&#45;&#45;label-n_pc" ftype="pdf" file="abundances&#45;&#45;med&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;med&#45;&#45;label-y_pc" ftype="pdf" file="abundances&#45;&#45;med&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;med_var" ftype="pdf" file="abundances&#45;&#45;med_var.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T0&#45;&#45;cell&#45;&#45;label-n_pc" ftype="pdf" file="abundances&#45;&#45;T0&#45;&#45;cell&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T0&#45;&#45;cell&#45;&#45;label-y_pc" ftype="pdf" file="abundances&#45;&#45;T0&#45;&#45;cell&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T0&#45;&#45;cell_var" ftype="pdf" file="abundances&#45;&#45;T0&#45;&#45;cell_var.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T0&#45;&#45;med&#45;&#45;label-n_pc" ftype="pdf" file="abundances&#45;&#45;T0&#45;&#45;med&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T0&#45;&#45;med&#45;&#45;label-y_pc" ftype="pdf" file="abundances&#45;&#45;T0&#45;&#45;med&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T0&#45;&#45;med_var" ftype="pdf" file="abundances&#45;&#45;T0&#45;&#45;med_var.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T2h&#45;&#45;cell&#45;&#45;label-n_pc" ftype="pdf" file="abundances&#45;&#45;T2h&#45;&#45;cell&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T2h&#45;&#45;cell&#45;&#45;label-y_pc" ftype="pdf" file="abundances&#45;&#45;T2h&#45;&#45;cell&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T2h&#45;&#45;cell_var" ftype="pdf" file="abundances&#45;&#45;T2h&#45;&#45;cell_var.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T2h&#45;&#45;med&#45;&#45;label-n_pc" ftype="pdf" file="abundances&#45;&#45;T2h&#45;&#45;med&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T2h&#45;&#45;med&#45;&#45;label-y_pc" ftype="pdf" file="abundances&#45;&#45;T2h&#45;&#45;med&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="abundances&#45;&#45;T2h&#45;&#45;med_var" ftype="pdf" file="abundances&#45;&#45;T2h&#45;&#45;med_var.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;cell&#45;&#45;label-n_pc" ftype="pdf" file="mean_enrichment&#45;&#45;cell&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;cell&#45;&#45;label-y_pc" ftype="pdf" file="mean_enrichment&#45;&#45;cell&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;cell_var" ftype="pdf" file="mean_enrichment&#45;&#45;cell_var.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;med&#45;&#45;label-n_pc" ftype="pdf" file="mean_enrichment&#45;&#45;med&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;med&#45;&#45;label-y_pc" ftype="pdf" file="mean_enrichment&#45;&#45;med&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;med_var" ftype="pdf" file="mean_enrichment&#45;&#45;med_var.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T0&#45;&#45;cell&#45;&#45;label-n_pc" ftype="pdf" file="mean_enrichment&#45;&#45;T0&#45;&#45;cell&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T0&#45;&#45;cell&#45;&#45;label-y_pc" ftype="pdf" file="mean_enrichment&#45;&#45;T0&#45;&#45;cell&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T0&#45;&#45;cell_var" ftype="pdf" file="mean_enrichment&#45;&#45;T0&#45;&#45;cell_var.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T0&#45;&#45;med&#45;&#45;label-n_pc" ftype="pdf" file="mean_enrichment&#45;&#45;T0&#45;&#45;med&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T0&#45;&#45;med&#45;&#45;label-y_pc" ftype="pdf" file="mean_enrichment&#45;&#45;T0&#45;&#45;med&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T0&#45;&#45;med_var" ftype="pdf" file="mean_enrichment&#45;&#45;T0&#45;&#45;med_var.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T2h&#45;&#45;cell&#45;&#45;label-n_pc" ftype="pdf" file="mean_enrichment&#45;&#45;T2h&#45;&#45;cell&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T2h&#45;&#45;cell&#45;&#45;label-y_pc" ftype="pdf" file="mean_enrichment&#45;&#45;T2h&#45;&#45;cell&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T2h&#45;&#45;cell_var" ftype="pdf" file="mean_enrichment&#45;&#45;T2h&#45;&#45;cell&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T2h&#45;&#45;med&#45;&#45;label-n_pc" ftype="pdf" file="mean_enrichment&#45;&#45;T2h&#45;&#45;med&#45;&#45;label-n_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T2h&#45;&#45;med&#45;&#45;label-y_pc" ftype="pdf" file="mean_enrichment&#45;&#45;T2h&#45;&#45;med&#45;&#45;label-y_pc.pdf" lines_diff="2" />-->
-<!--                <discovered_dataset designation="mean_enrichment&#45;&#45;T2h&#45;&#45;med_var" ftype="pdf" file="mean_enrichment&#45;&#45;T2h&#45;&#45;med_var.pdf" lines_diff="2" />-->
-<!--            </output>-->
-<!--        </test>-->
     </tests>
     <help><![CDATA[
     dimet @EXECUTABLE@

--- a/tools/dimet/dimet_pca_plot.xml
+++ b/tools/dimet/dimet_pca_plot.xml
@@ -55,36 +55,9 @@
     && tree .
     ]]></command>
     <inputs>
-        <param name="abundance_file" type="data" format="tabular" label="Metabolite abundance file"/>
-        <param name="me_or_frac_contrib_file" type="data" optional="true" format="tabular" label="Mean enrichment or fraction contribution file"/>
-        <param name="isotop_prop_file" type="data" optional="true" format="tabular" label="Isotopologues proportion abundance file"/>
-        <param name="isotop_abs_file" type="data" optional="true" format="tabular" label="Isotopologues absolute abundance file"/>
-        <param name="metadata_path" type="data" format="tabular" label="metadata file"/>
-        <param name="suffix" type="text" optional="false" label="suffix to add to output files" >
-            <sanitizer invalid_char="">
-                <valid initial="string.ascii_letters,string.digits">
-                    <add value="_" />
-                </valid>
-            </sanitizer>
-        </param>
-        <param name="conditions" type="select" optional="false" multiple="true" label="Browse conditions from metadata file (2 Max.). You have to load a metadata file prior to have acccess to metabolite list">
-            <options from_dataset="metadata_path">
-                <column name="condition" index="1"/>
-                <column name="value" index="1"/>
-                <filter type="unique_value" name="condition" column="condition"/>
-                <filter type="remove_value" value="condition"/>
-                <!--                <filter type="sort_by" name="timepoint" column="1"/>-->
-            </options>
-            <sanitizer>
-                <valid initial="default">
-                    <add preset="string.printable"/>
-                    <add value="\t"/>
-                    <remove value="&quot;"/>
-                    <remove value="&apos;"/>
-                </valid>
-            </sanitizer>
-        </param>
-
+        <expand macro="input_parameters"/>
+        <expand macro="suffix"/>
+        <expand macro="conditions"/>
     </inputs>
 
     <outputs>

--- a/tools/dimet/dimet_timecourse_analysis.xml
+++ b/tools/dimet/dimet_timecourse_analysis.xml
@@ -129,13 +129,9 @@
             '++analysis.dataset.isotopologues=isotop_abs'
          #end if
 
-
-    && cp '${report.extra_files_path}'/'${suffix}'-time_course_analysis/tables/*.tsv ./.
-    && rm -r '${report.extra_files_path}'/raw
-    && rm -r '${report.extra_files_path}'/config
-
-
-
+    && cp '${report.extra_files_path}/${suffix}'-time_course_analysis/tables/*.tsv ./.
+    && rm -r '${report.extra_files_path}/raw'
+    && rm -r '${report.extra_files_path}/config'
 
     ]]></command>
     <inputs>

--- a/tools/dimet/dimet_timecourse_analysis.xml
+++ b/tools/dimet/dimet_timecourse_analysis.xml
@@ -251,7 +251,7 @@
             <param name="conditions" value='"Control","L-Cycloserine"'/>
             <param name="timepoint" value='"T0","T2h"'/>
             <param name="grouping" value="condition,timepoint"/>
-            <output name="report" file="report.html" count="14"/>
+            <output name="report" file="report.html"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/dimet/macros.xml
+++ b/tools/dimet/macros.xml
@@ -38,6 +38,62 @@
             </citation>
         </citations>
     </xml>
+    <xml name="input_parameters">
+        <param name="abundance_file" type="data" format="tabular" label="Metabolite abundance file"/>
+        <param name="me_or_frac_contrib_file" type="data" optional="true" format="tabular" label="Mean enrichment or fraction contribution file"/>
+        <param name="isotop_prop_file" type="data" optional="true" format="tabular" label="Isotopologues proportion abundance file"/>
+        <param name="isotop_abs_file" type="data" optional="true" format="tabular" label="Isotopologues absolute abundance file"/>
+        <param name="metadata_path" type="data" format="tabular" label="metadata file"/>  
+    </xml>
+    <xml name="suffix">
+        <param name="suffix" type="text" optional="false" label="suffix to add to output files" >
+            <sanitizer invalid_char="">
+                <valid initial="string.ascii_letters,string.digits">
+                    <add value="_" />
+                </valid>
+            </sanitizer>
+        </param>      
+    </xml>
+    <xml name="conditions">
+        <param name="conditions" type="select" optional="false" multiple="true" label="Browse conditions from metadata file (2 Max.). You have to load a metadata file prior to have acccess to metabolite list">
+            <options from_dataset="metadata_path">
+                <column name="condition" index="1"/>
+                <column name="value" index="1"/>
+                <filter type="unique_value" name="condition" column="condition"/>
+                <filter type="remove_value" value="condition"/>
+                <!--                <filter type="sort_by" name="timepoint" column="1"/>-->
+            </options>
+            <sanitizer>
+                <valid initial="default">
+                    <add preset="string.printable"/>
+                    <add value="\t"/>
+                    <remove value="&quot;"/>
+                    <remove value="&apos;"/>
+                </valid>
+            </sanitizer>
+        </param>
+    </xml>
+    
+    <xml name="timepoint">
+        <param name="timepoint" type="select" optional="true" multiple="true" label="Browse timepoint from metadata file (2 Max.)">
+            <options from_dataset="metadata_path">
+                <column name="timepoint" index="2"/>
+                <column name="value" index="2"/>
+                <filter type="unique_value" name="timepoint" column="2"/>
+                <filter type="remove_value" value="timepoint"/>
+                <filter type="sort_by" name="timepoint" column="1"/>
+            </options>
+            <sanitizer>
+                <valid initial="default">
+                    <add preset="string.printable"/>
+                    <add value="\t"/>
+                    <remove value="&quot;"/>
+                    <remove value="&apos;"/>
+                </valid>
+            </sanitizer>
+        </param>
+    </xml>
+
     <token name="@INIT@"><![CDATA[
     #import json
     #import re

--- a/tools/dimet/macros.xml
+++ b/tools/dimet/macros.xml
@@ -28,8 +28,49 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">10.3389/fbinf.2022.867111</citation>
+            <citation type="bibtex">
+                @software{Galvis_Rodriguez_DIMet,
+                    author = {Galvis Rodriguez, Johanna  and Guyon, Joris and Dartigues, Benjamin and Specque, Florian and Daubon, Thomas and Karkar, Slim and Nikolski, Macha},
+                    license = {MIT},
+                    title = {{DIMet}},
+                    url = {https://github.com/cbib/DIMet}
+                    }
+            </citation>
         </citations>
     </xml>
+    <token name="@INIT@"><![CDATA[
+    #import json
+    #import re
+
+    mkdir -p data/raw &&
+    mkdir -p data/processed &&
+
+    #if $metadata_path:
+        ln '$metadata_path' data/raw/metadata.csv &&
+    #end if
+
+    #set $impute_values  = {}
+    #if $abundance_file:
+        ln '$abundance_file' data/raw/abundance.csv &&
+        #silent $impute_values['abundances']=re.sub('"', '', "min")
+    #end if
+    #if $me_or_frac_contrib_file:
+        ln '$me_or_frac_contrib_file' data/raw/me_or_frac_contrib.csv &&
+        #silent $impute_values['mean_enrichment']=re.sub('"', '', "min")
+    #end if
+    #if $isotop_abs_file:
+        ln '$isotop_abs_file' data/raw/isotop_abs.csv &&
+        #silent $impute_values['isotop_abs']=re.sub('"', '', "min")
+    #end if
+
+    #if $isotop_prop_file:
+        ln '$isotop_prop_file' data/raw/isotop_prop.csv &&
+        #silent $impute_values['isotop_prop']=re.sub('"', '', "min")
+    #end if
+    #set $conds = list()
+    #for $co in $conditions:
+        $conds.append(re.sub('"', '', str($co)))
+    #end for 
+    ]]></token>
 
 </macros>


### PR DESCRIPTION
This PR provides a sort of working version for the PCA tools to provide a template for the other tools. The tool now creates a collection of pdfs (plot) or tables (analysis).

Especially the output should not be an html file which serves as a container for everything else - it works just with it being a collection of PDFs which can then be downloaded or displayed in Galaxy.

This also fixes the count problem - I just didn't update the test cases yet. In general, less test data should be used - ideally one set of input data on which all tools are run.

Also the folder structure is now fixed and the common code for initiating the files is in a macro so it can be shared amongst all tools. This should also be done for parameters - to be put into a macro - and then for the help text as well.